### PR TITLE
Cleanup the init file

### DIFF
--- a/qiskit/transpiler/passes/synthesis/__init__.py
+++ b/qiskit/transpiler/passes/synthesis/__init__.py
@@ -13,7 +13,4 @@
 """Module containing transpiler synthesis passes."""
 
 from .unitary_synthesis import UnitarySynthesis
-from .solovay_kitaev import SolovayKitaevDecomposition, commutator_decompose
-from .solovay_kitaev_utils import (
-    GateSequence
-) 
+from .solovay_kitaev import SolovayKitaevDecomposition

--- a/test/python/transpiler/test_solovay_kitaev.py
+++ b/test/python/transpiler/test_solovay_kitaev.py
@@ -23,16 +23,16 @@ import hypothesis.strategies as st
 from scipy.optimize import minimize
 from scipy.stats import special_ortho_group
 from ddt import ddt, data, unpack
-import qiskit.circuit.library as gates
 
 from qiskit.circuit import Gate, QuantumCircuit
+import qiskit.circuit.library as gates
 from qiskit.circuit.library import TGate, RXGate, RYGate, HGate, SGate, IGate
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.transpiler.passes import SolovayKitaevDecomposition
-from qiskit.transpiler.passes.synthesis import commutator_decompose
 from qiskit.test import QiskitTestCase
 from qiskit.quantum_info import Operator
-from qiskit.transpiler.passes.synthesis import GateSequence 
+from qiskit.transpiler.passes.synthesis.solovay_kitaev import commutator_decompose
+from qiskit.transpiler.passes.synthesis.solovay_kitaev_utils import GateSequence 
 
 # pylint: disable=invalid-name, missing-class-docstring
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Let the init file only import the transformation pass and use the full import path in the tests for `GateSequence` and `commutator_decompose`.




