### PR TITLE
Allow caching the basic approximations

### DIFF
--- a/test/python/transpiler/test_solovay_kitaev.py
+++ b/test/python/transpiler/test_solovay_kitaev.py
@@ -235,7 +235,7 @@ class TestSolovayKitaev(QiskitTestCase):
 
         basic_gates = [HGate(), TGate(), SGate(), gates.IGate(), HGate().inverse(), TdgGate(),
                        SdgGate(), RXGate(math.pi), RYGate(math.pi)]
-        synth = SolovayKitaevDecomposition(3, basic_gates)
+        synth = SolovayKitaevDecomposition(3, basic_gates, 3)
 
         dag = circuit_to_dag(circuit)
         decomposed_dag = synth.run(dag)
@@ -250,7 +250,7 @@ class TestSolovayKitaev(QiskitTestCase):
 
         basic_gates = [HGate(), TGate(), SGate(), gates.IGate(), HGate().inverse(), TdgGate(),
                        SdgGate(), RXGate(math.pi), RYGate(math.pi)]
-        synth = SolovayKitaevDecomposition(3, basic_gates)
+        synth = SolovayKitaevDecomposition(3, basic_gates, 3)
 
         dag = circuit_to_dag(circuit)
         decomposed_dag = synth.run(dag)
@@ -265,7 +265,7 @@ class TestSolovayKitaev(QiskitTestCase):
 
         basic_gates = [HGate(), TGate(), SGate(), gates.IGate(), HGate().inverse(), TdgGate(),
                        SdgGate(), RXGate(math.pi), RYGate(math.pi)]
-        synth = SolovayKitaevDecomposition(3, basic_gates)
+        synth = SolovayKitaevDecomposition(3, basic_gates, 3)
 
         dag = circuit_to_dag(circuit)
         decomposed_dag = synth.run(dag)
@@ -280,7 +280,7 @@ class TestSolovayKitaev(QiskitTestCase):
 
         basic_gates = [HGate(), TGate(), SGate(), gates.IGate(), HGate().inverse(), TdgGate(),
                        SdgGate(), RXGate(math.pi), RYGate(math.pi)]
-        synth = SolovayKitaevDecomposition(3, basic_gates)
+        synth = SolovayKitaevDecomposition(3, basic_gates, 3)
 
         dag = circuit_to_dag(circuit)
         decomposed_dag = synth.run(dag)
@@ -295,7 +295,7 @@ class TestSolovayKitaev(QiskitTestCase):
 
         basic_gates = [HGate(), TGate(), SGate(), gates.IGate(), HGate().inverse(), TdgGate(),
                        SdgGate(), RXGate(math.pi), RYGate(math.pi)]
-        synth = SolovayKitaevDecomposition(3, basic_gates)
+        synth = SolovayKitaevDecomposition(3, basic_gates, 3)
 
         dag = circuit_to_dag(circuit)
         decomposed_dag = synth.run(dag)
@@ -310,7 +310,7 @@ class TestSolovayKitaev(QiskitTestCase):
 
         basic_gates = [HGate(), TGate(), SGate(), gates.IGate(), HGate().inverse(), TdgGate(),
                        SdgGate(), RXGate(math.pi), RYGate(math.pi)]
-        synth = SolovayKitaevDecomposition(3, basic_gates)
+        synth = SolovayKitaevDecomposition(3, basic_gates, 3)
 
         dag = circuit_to_dag(circuit)
         decomposed_dag = synth.run(dag)
@@ -324,7 +324,7 @@ class TestSolovayKitaev(QiskitTestCase):
         circuit = QFT(nr_qubits, 0)
         basic_gates = [HGate(), TGate(), SGate(), gates.IGate(), HGate().inverse(), TdgGate(),
                        SdgGate(), RXGate(math.pi), RYGate(math.pi)]
-        synth = SolovayKitaevDecomposition(4, basic_gates)
+        synth = SolovayKitaevDecomposition(4, basic_gates, 3)
 
         dag = circuit_to_dag(circuit)
         decomposed_dag = synth.run(dag)
@@ -339,7 +339,7 @@ class TestSolovayKitaev(QiskitTestCase):
         circuit = QFT(nr_qubits, 0)
         basic_gates = [TGate(), SGate(), gates.IGate(), TdgGate(),
                        SdgGate(), RXGate(math.pi), RYGate(math.pi)]
-        synth = SolovayKitaevDecomposition(4, basic_gates)
+        synth = SolovayKitaevDecomposition(4, basic_gates, 3)
 
         dag = circuit_to_dag(circuit)
         decomposed_dag = synth.run(dag)
@@ -353,7 +353,7 @@ class TestSolovayKitaev(QiskitTestCase):
         circuit.rx(0.8, 0)
 
         basis_gates = ['h', 't', 's']
-        synth = SolovayKitaevDecomposition(2, basis_gates)
+        synth = SolovayKitaevDecomposition(2, basis_gates, 3)
 
         dag = circuit_to_dag(circuit)
         discretized = dag_to_circuit(synth.run(dag))
@@ -375,8 +375,8 @@ class TestSolovayKitaev(QiskitTestCase):
 
         basic_gates = [HGate(), TGate(), SGate(), gates.IGate(), HGate().inverse(), TdgGate(),
                        SdgGate(), RXGate(math.pi), RYGate(math.pi)]
-        synth = SolovayKitaevDecomposition(depth, basic_gates)
-        synth_plus_one = SolovayKitaevDecomposition(depth+1, basic_gates)
+        synth = SolovayKitaevDecomposition(depth, basic_gates, 3)
+        synth_plus_one = SolovayKitaevDecomposition(depth+1, basic_gates, 3)
 
         dag = circuit_to_dag(circuit)
         decomposed_dag = synth.run(dag)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Allow caching the basic approximations for performance.

### Details and comments

Now we can use this as
```python
from qiskit.transpiler.passes import SolovayKitaevDecomposition

fname = 'depth10.npy'
sk = SolovayKitaevDecomposition()
sk.generate_basic_approximations(fname, ['h', 't', 'tdg'], 10)  # takes about 8 minutes
```
Load and run:
```python
from qiskit import transpile
from qiskit.circuit.library import QFT
from qiskit.converters import circuit_to_dag, dag_to_circuit
from qiskit.transpiler.passes import SolovayKitaevDecomposition
from qiskit.quantum_info import diamond_norm, Choi

circuit = QFT(3)
basis = ['u', 'cx']
circuit = transpile(circuit, basis_gates=basis, optimization_level=0)

skd = SolovayKitaevDecomposition(recursion_degree)
skd.load_basic_approximations('depth10.npy')

discretized = dag_to_circuit(skd.run(dag))  # takes about 8 seconds instead of 8 minutes as before

print(diamond_norm(Choi(circuit) - Choi(discretized)))
```
